### PR TITLE
Avoid unnecessary lets

### DIFF
--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -6,8 +6,6 @@ describe Marqeta::Card do
 
   describe 'class methods' do
     describe '.from_pan' do
-      let(:from_pan) { Marqeta::Card.from_pan(pan) }
-
       before do
         allow_any_instance_of(Marqeta::ApiCaller)
           .to(receive(:post))
@@ -19,21 +17,26 @@ describe Marqeta::Card do
           .to(receive(:new))
           .with('cards/getbypan')
           .and_call_original
-        from_pan
+        fetch_card_from_pan
       end
 
       it 'posts the pan to an ApiCaller' do
         expect_any_instance_of(Marqeta::ApiCaller)
           .to(receive(:post))
           .with(pan: pan)
-        from_pan
+        fetch_card_from_pan
       end
 
       it 'returns a Card with token set correctly' do
-        card = from_pan
+        card = fetch_card_from_pan
         expect(card).to be_a(Marqeta::Card)
         expect(card.token).to eq(card_token)
       end
+
+    end
+
+    def fetch_card_from_pan
+      Marqeta::Card.from_pan(pan)
     end
   end
 

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe Marqeta::Transaction do
   describe 'class methods' do
     describe '.since' do
-      let(:since) { Marqeta::Transaction.since(start_time) }
       let(:start_time) { Time.new(2018, 1, 1, 0, 0, 0, '-05:00') }
 
       before do
@@ -39,22 +38,26 @@ describe Marqeta::Transaction do
           .with('transactions', params)
           .and_call_original
 
-        since
+        fetch_transactions_since
       end
 
       it 'calls get on an ApiCaller' do
         expect_any_instance_of(Marqeta::ApiCaller).to(receive(:get))
-        since
+        fetch_transactions_since
       end
 
       it 'returns expected Tranaction objects' do
-        transactions = since
+        transactions = fetch_transactions_since
         expect(transactions.length).to eq(2)
         expect(transactions.map(&:class).uniq).to eq([Marqeta::Transaction])
         expect(transactions.map(&:token)).to eq(%w[token1 token2])
         expect(transactions.map(&:state)).to eq(%w[PENDING DECLINED])
         expect(transactions.map(&:user_token)).to eq(%w[user_token1 user_token2])
         expect(transactions.map(&:amount)).to eq([1000, 2000])
+      end
+
+      def fetch_transactions_since
+        Marqeta::Transaction.since(start_time)
       end
     end
   end


### PR DESCRIPTION
`let` can be useful if we need to memoize a value, but here a plain
method call is equivalent.