### PR TITLE
Specify license in gemspec

### DIFF
--- a/marqeta.gemspec
+++ b/marqeta.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Integration with Marqeta API'
   spec.homepage      = 'https://github.com/financeit/marqeta'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
rubygems.org uses this field to display the license.