### PR TITLE
Make dependencies explicit

### DIFF
--- a/lib/marqeta.rb
+++ b/lib/marqeta.rb
@@ -1,7 +1,6 @@
 require 'marqeta/api_caller'
 require 'marqeta/card'
 require 'marqeta/client_access'
-require 'marqeta/errors'
 require 'marqeta/gateway_response_codes'
 require 'marqeta/kyc'
 require 'marqeta/one_time'

--- a/lib/marqeta.rb
+++ b/lib/marqeta.rb
@@ -5,7 +5,6 @@ require 'marqeta/kyc'
 require 'marqeta/one_time'
 require 'marqeta/transaction'
 require 'marqeta/transaction_channels'
-require 'marqeta/transaction_response_codes'
 require 'marqeta/user'
 require 'marqeta/version'
 

--- a/lib/marqeta.rb
+++ b/lib/marqeta.rb
@@ -1,4 +1,3 @@
-require 'marqeta/api_caller'
 require 'marqeta/card'
 require 'marqeta/client_access'
 require 'marqeta/gateway_response_codes'

--- a/lib/marqeta.rb
+++ b/lib/marqeta.rb
@@ -1,5 +1,4 @@
 require 'marqeta/api_caller'
-require 'marqeta/api_object'
 require 'marqeta/card'
 require 'marqeta/client_access'
 require 'marqeta/errors'

--- a/lib/marqeta/api_caller.rb
+++ b/lib/marqeta/api_caller.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'rest-client'
+require 'marqeta/errors'
 
 module Marqeta
   class ApiCaller

--- a/lib/marqeta/api_object.rb
+++ b/lib/marqeta/api_object.rb
@@ -1,3 +1,5 @@
+require 'marqeta/api_caller'
+
 module Marqeta
   class ApiObject
     QUERY_RESULTS_COUNT = 100

--- a/lib/marqeta/card.rb
+++ b/lib/marqeta/card.rb
@@ -1,4 +1,5 @@
 require 'marqeta/api_object'
+require 'marqeta/client_access'
 
 module Marqeta
   class Card < ApiObject

--- a/lib/marqeta/card.rb
+++ b/lib/marqeta/card.rb
@@ -1,3 +1,5 @@
+require 'marqeta/api_object'
+
 module Marqeta
   class Card < ApiObject
     ACTIVE_STATE = 'ACTIVE'.freeze

--- a/lib/marqeta/client_access.rb
+++ b/lib/marqeta/client_access.rb
@@ -1,3 +1,5 @@
+require 'marqeta/api_object'
+
 module Marqeta
   class ClientAccess < ApiObject
     def self.endpoint

--- a/lib/marqeta/kyc.rb
+++ b/lib/marqeta/kyc.rb
@@ -1,3 +1,5 @@
+require 'marqeta/api_object'
+
 module Marqeta
   class Kyc < ApiObject
     def self.endpoint

--- a/lib/marqeta/one_time.rb
+++ b/lib/marqeta/one_time.rb
@@ -1,3 +1,5 @@
+require 'marqeta/api_object'
+
 module Marqeta
   class OneTime < ApiObject
     def self.endpoint

--- a/lib/marqeta/transaction.rb
+++ b/lib/marqeta/transaction.rb
@@ -1,3 +1,5 @@
+require 'marqeta/api_object'
+
 module Marqeta
   class Transaction < ApiObject
     PENDING_STATE = 'PENDING'.freeze

--- a/lib/marqeta/transaction.rb
+++ b/lib/marqeta/transaction.rb
@@ -1,3 +1,4 @@
+require 'marqeta/api_caller'
 require 'marqeta/api_object'
 
 module Marqeta

--- a/lib/marqeta/transaction.rb
+++ b/lib/marqeta/transaction.rb
@@ -1,5 +1,6 @@
 require 'marqeta/api_caller'
 require 'marqeta/api_object'
+require 'marqeta/gateway_response_codes'
 
 module Marqeta
   class Transaction < ApiObject

--- a/lib/marqeta/transaction.rb
+++ b/lib/marqeta/transaction.rb
@@ -1,6 +1,7 @@
 require 'marqeta/api_caller'
 require 'marqeta/api_object'
 require 'marqeta/gateway_response_codes'
+require 'marqeta/transaction_response_codes'
 
 module Marqeta
   class Transaction < ApiObject

--- a/lib/marqeta/user.rb
+++ b/lib/marqeta/user.rb
@@ -1,3 +1,5 @@
+require 'marqeta/api_object'
+
 module Marqeta
   class User < ApiObject
     def self.endpoint

--- a/spec/marqeta/api_object_spec.rb
+++ b/spec/marqeta/api_object_spec.rb
@@ -1,3 +1,5 @@
+require 'marqeta/api_object'
+
 describe Marqeta::ApiObject do
   let(:endpoint) { 'foo' }
 


### PR DESCRIPTION
The number of dependencies acts as a useful form of design feedback. A high number of them indicates the class may be overly complex or have too many responsibilities.