### PR TITLE
Require spec_helper by default

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/marqeta/api_caller_spec.rb
+++ b/spec/marqeta/api_caller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Marqeta::ApiCaller do
   subject(:api_caller) { Marqeta::ApiCaller.new(endpoint, params) }
 

--- a/spec/marqeta/api_object_spec.rb
+++ b/spec/marqeta/api_object_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Marqeta::ApiObject do
   let(:endpoint) { 'foo' }
 

--- a/spec/marqeta/card_spec.rb
+++ b/spec/marqeta/card_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Marqeta::Card do
   let(:pan) { '1234567890' }
   let(:card_token) { 'CARD_TOKEN' }

--- a/spec/marqeta/transaction_spec.rb
+++ b/spec/marqeta/transaction_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Marqeta::Transaction do
   describe 'class methods' do
     describe '.index' do

--- a/spec/marqeta/user_spec.rb
+++ b/spec/marqeta/user_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Marqeta::User do
   subject(:user) { Marqeta::User.new(token: user_token, metadata: metadata) }
 


### PR DESCRIPTION
Since the project only has one kind of `spec_helper`, let's require it by default. This follows the RSpec convention when using `rspec --init`.