### PR TITLE
PLAT-861: Update Marqeta tests to be Ruby 3 compatible

### DIFF
--- a/spec/marqeta/user_spec.rb
+++ b/spec/marqeta/user_spec.rb
@@ -26,37 +26,37 @@ describe Marqeta::User do
 
   describe '#create_child' do
     it "creates a User resource passing in the user's token and uses_parent_account: true" do
-      expect(Marqeta::User).to receive(:api_create).with(parent_token: user_token, uses_parent_account: false)
+      expect(Marqeta::User).to receive(:api_create).with({ parent_token: user_token, uses_parent_account: false })
       user.create_child
     end
 
     it 'allows passing in extra parameters' do
       extra_params = { foo: 'bar' }
-      expect(Marqeta::User).to receive(:api_create).with(
+      expect(Marqeta::User).to receive(:api_create).with({
         parent_token: user_token,
         uses_parent_account: false,
-        foo: 'bar'
-      )
+        foo: 'bar',
+      })
       user.create_child(extra_params)
     end
   end
 
   describe '#create_onetime' do
     it "creates a OneTime resource passing in the user's token" do
-      expect(Marqeta::OneTime).to receive(:api_create).with(user_token: user_token)
+      expect(Marqeta::OneTime).to receive(:api_create).with({ user_token: user_token })
       user.create_onetime
     end
   end
 
   describe '#perform_kyc' do
     it "creates a Kyc resource passing in the user's token" do
-      expect(Marqeta::Kyc).to receive(:api_create).with(user_token: user_token)
+      expect(Marqeta::Kyc).to receive(:api_create).with({ user_token: user_token })
       user.perform_kyc
     end
 
     it 'allows passing in extra parameters' do
       extra_params = { manual_override: true }
-      expect(Marqeta::Kyc).to receive(:api_create).with(user_token: user_token, manual_override: true)
+      expect(Marqeta::Kyc).to receive(:api_create).with({ user_token: user_token, manual_override: true })
       user.perform_kyc(extra_params)
     end
   end


### PR DESCRIPTION
Ruby 3 no longer implicitly converts options hashes into kwargs, so the expected args in the tests are to be updated to hashes to reflect the `api_create` function definition 
https://financeit.atlassian.net/browse/PLAT-861

Sample failure when the specs are ran in Ruby 3.0.5:
```ruby
 1) Marqeta::User#create_child creates a User resource passing in the user's token and uses_parent_account: true
     Failure/Error: self.class.api_create(extra_params.merge(uses_parent_account: false, parent_token: token))
     
       #<Marqeta::User (class)> received :api_create with unexpected arguments
         expected: ({:parent_token=>"user_token", :uses_parent_account=>false}) (keyword arguments)
              got: ({:parent_token=>"user_token", :uses_parent_account=>false}) (options hash)
     # ./lib/marqeta/user.rb:22:in `create_child'
     # ./spec/marqeta/user_spec.rb:30:in `block (3 levels) in <top (required)>'
```
Remaining failures are on the Jira ticket description